### PR TITLE
Add [super layoutSublayers] to layoutSublayers

### DIFF
--- a/DAAttributedStringUtils/DAAttributedLabel.m
+++ b/DAAttributedStringUtils/DAAttributedLabel.m
@@ -92,6 +92,8 @@
 @implementation DAAttributedLabelBaseLayer
 - (void) layoutSublayers
 {
+        [super layoutSublayers];
+        
 	[CATransaction begin];
 	[CATransaction setValue:(id)kCFBooleanTrue forKey:kCATransactionDisableActions];
 	for (CALayer* layer in self.sublayers) {


### PR DESCRIPTION
Need to add [super layoutSublayers]; to DAAttributedLabelBaseLayer-layoutSublayers of DAAttributedLabel.m, or the text won't resize when rotating device.

Please see the bug in my demo: https://github.com/hanton/layoutSublayersDemo
